### PR TITLE
Bump poi from 3.16-beta2 to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>3.16-beta2</version>
+			<version>4.1.1</version>
 		</dependency>
 
 
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>3.9</version>
+			<version>4.1.1</version>
 		</dependency>
 		
 


### PR DESCRIPTION
Bumps poi from 3.16-beta2 to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi dependency-type: direct:production ...